### PR TITLE
Fix file extension filtering to support compound extensions

### DIFF
--- a/src/file_scanner.rs
+++ b/src/file_scanner.rs
@@ -43,7 +43,13 @@ pub fn scan_files(
             // Apply type filter only to files
             let keep = types_filter
                 .iter()
-                .any(|ext_filter_str| path.extension() == Some(OsStr::new(ext_filter_str)));
+                .any(|ext_filter_str| {
+                    let file_name = path.file_name()
+                        .and_then(|name| name.to_str())
+                        .unwrap_or("");
+                    let ext_with_dot = format!(".{}", ext_filter_str);
+                    file_name.ends_with(&ext_with_dot)
+                });
             if !keep {
                 continue;
             }


### PR DESCRIPTION
- Change extension matching from path.extension() to filename.ends_with()
- This allows filtering by compound extensions like 'contract.json'
- Fixes issue where files like 'filename.contract.json' were not matched when using -t contract.json

Previously, only the last extension (after final dot) was considered. Now the entire suffix after a dot is matched, enabling compound extensions.