### PR TITLE
Add -o option to write repoyank output to file

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@
 - **TUI Pre-selection:** Highlight items matching glob patterns on TUI start-up.
 - **Direct Yanking (`--all`):** Skip the TUI and directly yank files matching patterns and filters.
 - **Dry Run Mode:** Preview what would be selected and copied without touching the clipboard.
+- **File Output:** Use `-o <file>` to write the generated output directly to a file instead of copying it.
 - **Clipboard Integration:** Works smoothly across Linux (Wayland/X11), macOS, and Windows via `arboard`.
 - **Git-aware:** Optional inclusion of files normally ignored by `.gitignore`.
 
@@ -72,6 +73,7 @@ repoyank [OPTIONS] [PATTERN ...]
 | `-s`  | `--select <GLOB[,...]>` | Pre-select items in the TUI matching these globs. Globs are relative to the scan root. User can still change pick. |
 | `-i`  | `--include-ignored`     | Include files that are normally excluded by `.gitignore`.                                                             |
 | `-n`  | `--dry-run`             | Print the final tree and selection summary, but **don't** touch the clipboard.                                    |
+| `-o`  | `--output <FILE>`       | Write generated output to `FILE` instead of copying to the clipboard.                                              |
 | `-h`  | `--help`                | Show help information.                                                                                              |
 | `-V`  | `--version`             | Show version information.                                                                                           |
 
@@ -117,6 +119,16 @@ repoyank [OPTIONS] [PATTERN ...]
     repoyank -n -a 'docs/**/*.md'
     ```
 
+8.  **Write all matching Rust files to a file, including from a subdirectory:**
+    ```bash
+    repoyank -a -t rs src/ -o /tmp/repoyank-output.txt
+    ```
+
+9.  **Use a relative output path from your current directory:**
+    ```bash
+    repoyank -a 'docs/**/*.md' -o exports/docs-snippet.md
+    ```
+
 8.  **Include generated files (e.g., in `build/`) that are in `.gitignore`:**
     ```bash
     repoyank -i 'build/**/*'
@@ -144,7 +156,7 @@ File: README.md
 ...
 ```
 
-And `repoyank` will provide a helpful confirmation on your console, including the tree structure that was copied:
+And `repoyank` will provide a helpful confirmation on your console, including the tree structure that was copied or saved:
 
 ```
 ./

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -25,6 +25,7 @@ OPTIONS (see `repoyank --help` for full details):
     -s, --select <GLOB[,...]> Pre-select TUI items matching these globs.
     -i, --include-ignored     Include files ignored by .gitignore.
     -n, --dry-run             Print selection and tree, but don't copy to clipboard.
+    -o, --output <FILE>       Write output to FILE instead of clipboard.
     -h, --help                Show help.
     -V, --version             Show version.
 
@@ -81,4 +82,8 @@ pub struct Cli {
     /// Print selection and tree, but don't copy to clipboard.
     #[arg(short = 'n', long)]
     pub dry_run: bool,
+
+    /// Write output to file instead of clipboard.
+    #[arg(short = 'o', long = "output", value_name = "FILE")]
+    pub output_file: Option<std::path::PathBuf>,
 }

--- a/src/workflow.rs
+++ b/src/workflow.rs
@@ -449,6 +449,7 @@ fn perform_final_action(
     is_dry_run: bool,
     initial_scan_was_empty_and_not_default: bool,
     output_tree_labels_for_console: &[String],
+    output_file: &Option<std::path::PathBuf>,
 ) -> Result<()> {
     if is_dry_run {
         print!("{}", output_string);
@@ -473,7 +474,7 @@ fn perform_final_action(
         }
         println!("No files were ultimately selected to copy. Exiting.");
         std::process::exit(1); // Non-zero exit for actual copy operation with no files.
-    } else {
+    } else if files_to_yank_count > 0 {
         // Print the tree structure to console
         if !output_tree_labels_for_console.is_empty() {
             for label in output_tree_labels_for_console {
@@ -482,12 +483,27 @@ fn perform_final_action(
             println!();
         }
 
-        clipboard::copy_text_to_clipboard(output_string.to_string())?;
         let tokens = utils::approx_tokens(output_string);
-        println!(
-            "✅ Copied {} files (≈ {} tokens) to the clipboard.",
-            files_to_yank_count, tokens
-        );
+        if let Some(output_path) = output_file.as_ref() {
+            if let Some(parent) = output_path.parent() {
+                if !parent.as_os_str().is_empty() {
+                    fs::create_dir_all(parent)?;
+                }
+            }
+            fs::write(output_path, output_string)?;
+            println!(
+                "✅ Wrote {} files (≈ {} tokens) to {}",
+                files_to_yank_count,
+                tokens,
+                output_path.display()
+            );
+        } else {
+            clipboard::copy_text_to_clipboard(output_string.to_string())?;
+            println!(
+                "✅ Copied {} files (≈ {} tokens) to the clipboard.",
+                files_to_yank_count, tokens
+            );
+        }
     }
     Ok(())
 }
@@ -599,6 +615,7 @@ pub fn run_repoyank(cli_args: cli::Cli) -> Result<()> {
         cli_args.dry_run,
         initial_scan_was_empty_and_not_default_pattern,
         &console_tree_labels,
+        &cli_args.output_file,
     )?;
 
     Ok(())


### PR DESCRIPTION
## Summary
- Add `-o/--output` CLI option to write generated output to a file instead of clipboard.
- Support both relative and absolute output file paths.
- Document usage in README with examples and option table update.
- Preserve current default clipboard behavior when `-o` is not set.

## Test plan
- [x] cargo check (implicit during `cargo install --path .` during local install)
- [ ] Manual smoke test: `repoyank -a -t rs src/ -o /tmp/repoyank-output.txt`
- [ ] Manual smoke test: `repoyank -a -t rs src/ -o exports/repoyank-output.txt`
